### PR TITLE
Accept file with no blank line at the end

### DIFF
--- a/pre-receive-app
+++ b/pre-receive-app
@@ -8,7 +8,7 @@ APP="$1"; IMAGE_SOURCE_TYPE="$2"; TMP_WORK_DIR="$3"; REV="$4"
 
 dokku_log_info2 "Monorepo detected"
 
-while IFS="=" read -u 10 -a line; do
+while IFS="=" read -u 10 -a line || [[ -n $line ]]; do
   [[ "${line[0]}" == "#"* || "${line[1]}" == "" ]] && continue
   [[ $APP != *"${line[0]}"* ]] && continue
 


### PR DESCRIPTION
Hi, it turns out if the `.dokku-monorepo` doesn't end up with a blank line, the last line will never be parsed. This PR fixes it.

It also fixes issue https://github.com/iamale/dokku-monorepo/issues/4